### PR TITLE
Default attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,16 @@ mr.set_timer('timing-this-thing', timer)
 mr.flush()
 ```
 
+### Default attributes for non-custom metrics
+MetricRelay can create metrics with a common set of attributes as well:
+
+```python
+import shumway
+
+attributes = dict(foo='bar')
+mr = shumway.MetricRelay(SERVICE_NAME, default_attributes=attributes)
+```
+
 ### Sending Metrics
 
 There are two ways to send metrics to the `ffwd` agent:

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ False
 
 ### Custom FFWD agents
 
-By default, `shumway` will send metrics to a local [`ffwd`](https://github.com/spotify/ffwd) agent at `127.0.0.1:19000`. 
+By default, `shumway` will send metrics to a local [`ffwd`](https://github.com/spotify/ffwd) agent at `127.0.0.1:19000`.
 
 If your `ffwd` agent is elsewhere, then pass that information through when initializing the `MetricRelay`:
 
@@ -172,8 +172,6 @@ mr = shumway.MetricRelay(SERVICE_NAME, ffwd_ip='10.99.0.1', ffwd_port=19001)
 
 # do the thing
 ```
-
-
 
 # Developer Setup
 

--- a/shumway/__init__.py
+++ b/shumway/__init__.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import json
 import socket
 import time
@@ -86,11 +87,14 @@ class Timer(Meter):
 
 class MetricRelay(object):
     """Create and send metrics"""
-    def __init__(self, default_key, ffwd_ip=FFWD_IP, ffwd_port=FFWD_PORT):
+    def __init__(self, default_key, ffwd_ip=FFWD_IP, ffwd_port=FFWD_PORT,
+                 default_attributes=None):
         self._metrics = {}
         self._sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self._default_key = default_key
         self._ffwd_address = (ffwd_ip, ffwd_port)
+
+        self._default_attributes = copy.deepcopy(default_attributes)
 
     def emit(self, metric, value, attributes=None, tags=None):
         """Emit one-time metric that does not need to be stored."""
@@ -103,7 +107,8 @@ class MetricRelay(object):
         if metric in self._metrics:
             counter = self._metrics[metric]
         else:
-            counter = Counter(metric, key=self._default_key)
+            counter = Counter(metric, key=self._default_key,
+                              attributes=self._default_attributes)
             self._metrics[metric] = counter
         counter.incr(value)
 
@@ -112,7 +117,8 @@ class MetricRelay(object):
         if timer_metric in self._metrics:
             timer = self._metrics[timer_metric]
         else:
-            timer = Timer(metric, key=self._default_key)
+            timer = Timer(metric, key=self._default_key,
+                          attributes=self._default_attributes)
             self._metrics[timer_metric] = timer
         return timer
 


### PR DESCRIPTION
Allow setting attributes for non-custom metrics created by the MetricRelay