### PR TITLE
bump requests to 2.31.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests==2.25.1
+requests==2.31.0
 six==1.16.0


### PR DESCRIPTION
There is a critical security vulnerability here due to `requests` dependency on `certifi@2022.12.7`

https://nvd.nist.gov/vuln/detail/CVE-2023-37920

## Tests
I was having issues with `tox` so I ran manually

### Setup
```
pyenv install 3.6
pyenv global 3.6
pip3.6 install -r dev-requirements.txt
```
Repeat for 3.7 and 3.8

### Test Runs
```
➜ python3.6 -m nose test/metrics_test.py
......................
----------------------------------------------------------------------
Ran 22 tests in 0.021s

OK

➜ python3.7 -m nose test/metrics_test.py
......................
----------------------------------------------------------------------
Ran 22 tests in 0.017s

OK

➜ python3.8 -m nose test/metrics_test.py
......................
----------------------------------------------------------------------
Ran 22 tests in 0.017s

OK
```