### PR TITLE
bump gh runner version to ubuntu 22

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on: [push, release, workflow_dispatch]
 
 jobs:
   review:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, pypy3]
@@ -40,7 +40,7 @@ jobs:
 
   build_and_publish:
     needs: review
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v2


### PR DESCRIPTION
Bump to a supported runner version
https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources